### PR TITLE
Update config.py

### DIFF
--- a/sematic/config/config.py
+++ b/sematic/config/config.py
@@ -16,7 +16,7 @@ from sematic.versions import version_as_string
 logger = logging.getLogger(__name__)
 
 # Support for dropping columns added in 3.35.0
-MIN_SQLITE_VERSION = (3, 35, 0)
+MIN_SQLITE_VERSION = (3, 35)
 
 
 def _check_sqlite_version():


### PR DESCRIPTION
Anytime you I run the code `sematic new project`
This bug pops up
`Sematic will soon require the sqlite3 version to be at least 3.35.0, but your Python is using 3.35.5. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669`

So to fix it I changed  (3, 35, 0) to (3, 35)